### PR TITLE
Migrate from TestRestTemplate to RestTestClient

### DIFF
--- a/src/test/kotlin/no/nav/eux/pdf/integration/AbstractPdfApiImplTest.kt
+++ b/src/test/kotlin/no/nav/eux/pdf/integration/AbstractPdfApiImplTest.kt
@@ -1,21 +1,20 @@
 package no.nav.eux.pdf.integration
 
 import no.nav.eux.pdf.Application
-import no.nav.eux.pdf.integration.common.voidHttpEntity
+import no.nav.eux.pdf.integration.common.token
 import no.nav.eux.pdf.integration.mock.RequestBodies
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.resttestclient.TestRestTemplate
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.client.EntityExchangeResult
+import org.springframework.test.web.servlet.client.RestTestClient
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -28,14 +27,14 @@ import kotlin.test.assertTrue
 @ActiveProfiles("test")
 @EnableMockOAuth2Server
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@AutoConfigureTestRestTemplate
+@AutoConfigureRestTestClient
 abstract class AbstractPdfApiImplTest {
 
     @Autowired
     lateinit var mockOAuth2Server: MockOAuth2Server
 
     @Autowired
-    lateinit var restTemplate: TestRestTemplate
+    lateinit var restTestClient: RestTestClient
 
     @Autowired
     lateinit var requestBodies: RequestBodies
@@ -45,33 +44,29 @@ abstract class AbstractPdfApiImplTest {
     }
 
      fun callPdfEndpoint(endpoint: String) =
-        restTemplate.exchange(
-            endpoint,
-            HttpMethod.GET,
-            voidHttpEntity(mockOAuth2Server),
-            ByteArray::class.java
-        )
+        restTestClient.get().uri(endpoint)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
+            .expectBody(ByteArray::class.java)
+            .returnResult()
 
      fun callPdfEndpointExpectingError(endpoint: String) =
-        restTemplate.exchange(
-            endpoint,
-            HttpMethod.GET,
-            voidHttpEntity(mockOAuth2Server),
-            String::class.java
-        )
+        restTestClient.get().uri(endpoint)
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
+            .expectBody(String::class.java)
+            .returnResult()
 
      fun callUnauthenticatedEndpoint(endpoint: String) =
-        restTemplate.exchange(
-            endpoint,
-            HttpMethod.GET,
-            null,
-            String::class.java
-        )
+        restTestClient.get().uri(endpoint)
+            .exchange()
+            .expectBody(String::class.java)
+            .returnResult()
 
-     fun assertSuccessfulPdfResponse(response: ResponseEntity<ByteArray>) {
-        assertEquals(HttpStatus.OK, response.statusCode, "Should return HTTP 200")
-        assertEquals(MediaType.APPLICATION_PDF, response.headers.contentType, "Should return PDF content type")
-        assertNotNull(response.body, "Response body should not be null")
+     fun assertSuccessfulPdfResponse(response: EntityExchangeResult<ByteArray>) {
+        assertEquals(HttpStatus.OK, response.status, "Should return HTTP 200")
+        assertEquals(MediaType.APPLICATION_PDF, response.responseHeaders.contentType, "Should return PDF content type")
+        assertNotNull(response.responseBody, "Response body should not be null")
     }
 
      fun validatePdfFormat(pdfBytes: ByteArray) {
@@ -84,8 +79,8 @@ abstract class AbstractPdfApiImplTest {
         )
     }
 
-     fun validateContentDispositionHeader(response: ResponseEntity<ByteArray>, expectedFilename: String) {
-        val contentDisposition = response.headers.contentDisposition
+     fun validateContentDispositionHeader(response: EntityExchangeResult<ByteArray>, expectedFilename: String) {
+        val contentDisposition = response.responseHeaders.contentDisposition
         assertNotNull(contentDisposition, "Content-Disposition header should be present")
         assertEquals("attachment", contentDisposition.type, "Should be attachment type")
         assertEquals(expectedFilename, contentDisposition.filename, "Should have correct filename")

--- a/src/test/kotlin/no/nav/eux/pdf/integration/PdfControllerU020Test.kt
+++ b/src/test/kotlin/no/nav/eux/pdf/integration/PdfControllerU020Test.kt
@@ -31,7 +31,7 @@ class PdfControllerU020Test : AbstractPdfApiImplTest() {
             val response = callPdfEndpoint(endpoint)
             assertSuccessfulPdfResponse(response)
 
-            val pdfBytes = response.body!!
+            val pdfBytes = response.responseBody!!
             savePdfForInspection(pdfBytes, "complete-u020", "U020")
 
             verifyAllRinaEndpointsWereCalled()
@@ -48,7 +48,7 @@ class PdfControllerU020Test : AbstractPdfApiImplTest() {
             val response = callPdfEndpoint(endpoint)
             assertSuccessfulPdfResponse(response)
 
-            val pdfBytes = response.body!!
+            val pdfBytes = response.responseBody!!
             savePdfForInspection(pdfBytes, "multiple-claims", "U020")
 
             assertTrue(
@@ -71,7 +71,7 @@ class PdfControllerU020Test : AbstractPdfApiImplTest() {
             val endpoint = "/api/v1/rinasak/$NON_EXISTENT_CASE_ID/document/u020/$VALID_DOCUMENT_ID_U020"
             logTestInfo("Testing 404 response for non-existent case", endpoint)
             val response = callPdfEndpointExpectingError(endpoint)
-            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            assertEquals(HttpStatus.NOT_FOUND, response.status)
             logTestSuccess("Correctly returned 404 for non-existent case")
         }
 
@@ -81,7 +81,7 @@ class PdfControllerU020Test : AbstractPdfApiImplTest() {
             val endpoint = "/api/v1/rinasak/$VALID_CASE_ID_U20/document/u020/$NON_EXISTENT_DOCUMENT_ID"
             logTestInfo("Testing 404 response for non-existent document", endpoint)
             val response = callPdfEndpointExpectingError(endpoint)
-            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            assertEquals(HttpStatus.NOT_FOUND, response.status)
             logTestSuccess("Correctly returned 404 for non-existent document")
         }
 
@@ -91,7 +91,7 @@ class PdfControllerU020Test : AbstractPdfApiImplTest() {
             val endpoint = "/api/v1/rinasak/$VALID_CASE_ID_U20/document/u020/$VALID_DOCUMENT_ID_U020"
             logTestInfo("Testing 401 response for unauthenticated request", endpoint)
             val response = callUnauthenticatedEndpoint(endpoint)
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+            assertEquals(HttpStatus.UNAUTHORIZED, response.status)
             logTestSuccess("Correctly returned 401 for unauthenticated request")
         }
     }
@@ -120,7 +120,7 @@ class PdfControllerU020Test : AbstractPdfApiImplTest() {
             val response = callPdfEndpoint(endpoint)
             assertSuccessfulPdfResponse(response)
 
-            val pdfBytes = response.body!!
+            val pdfBytes = response.responseBody!!
             validatePdfFormat(pdfBytes)
 
             savePdfForInspection(pdfBytes, "format-validation", "U020")

--- a/src/test/kotlin/no/nav/eux/pdf/integration/PdfControllerU029Test.kt
+++ b/src/test/kotlin/no/nav/eux/pdf/integration/PdfControllerU029Test.kt
@@ -31,7 +31,7 @@ class PdfControllerU029Test : AbstractPdfApiImplTest() {
             val response = callPdfEndpoint(endpoint)
             assertSuccessfulPdfResponse(response)
 
-            val pdfBytes = response.body!!
+            val pdfBytes = response.responseBody!!
             savePdfForInspection(pdfBytes, "complete-u029", "U029")
 
             verifyAllRinaEndpointsWereCalled()
@@ -48,7 +48,7 @@ class PdfControllerU029Test : AbstractPdfApiImplTest() {
             val response = callPdfEndpoint(endpoint)
             assertSuccessfulPdfResponse(response)
 
-            val pdfBytes = response.body!!
+            val pdfBytes = response.responseBody!!
             savePdfForInspection(pdfBytes, "multiple-claims", "U029")
 
             assertTrue(
@@ -71,7 +71,7 @@ class PdfControllerU029Test : AbstractPdfApiImplTest() {
             val endpoint = "/api/v1/rinasak/$NON_EXISTENT_CASE_ID/document/u029/$VALID_DOCUMENT_ID_U029"
             logTestInfo("Testing 404 response for non-existent case", endpoint)
             val response = callPdfEndpointExpectingError(endpoint)
-            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            assertEquals(HttpStatus.NOT_FOUND, response.status)
             logTestSuccess("Correctly returned 404 for non-existent case")
         }
 
@@ -81,7 +81,7 @@ class PdfControllerU029Test : AbstractPdfApiImplTest() {
             val endpoint = "/api/v1/rinasak/$VALID_CASE_ID_U029/document/u029/$NON_EXISTENT_DOCUMENT_ID"
             logTestInfo("Testing 404 response for non-existent document", endpoint)
             val response = callPdfEndpointExpectingError(endpoint)
-            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            assertEquals(HttpStatus.NOT_FOUND, response.status)
             logTestSuccess("Correctly returned 404 for non-existent document")
         }
 
@@ -91,7 +91,7 @@ class PdfControllerU029Test : AbstractPdfApiImplTest() {
             val endpoint = "/api/v1/rinasak/$VALID_CASE_ID_U029/document/u029/$VALID_DOCUMENT_ID_U029"
             logTestInfo("Testing 401 response for unauthenticated request", endpoint)
             val response = callUnauthenticatedEndpoint(endpoint)
-            assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode)
+            assertEquals(HttpStatus.UNAUTHORIZED, response.status)
             logTestSuccess("Correctly returned 401 for unauthenticated request")
         }
     }
@@ -120,7 +120,7 @@ class PdfControllerU029Test : AbstractPdfApiImplTest() {
             val response = callPdfEndpoint(endpoint)
             assertSuccessfulPdfResponse(response)
 
-            val pdfBytes = response.body!!
+            val pdfBytes = response.responseBody!!
             validatePdfFormat(pdfBytes)
 
             savePdfForInspection(pdfBytes, "format-validation", "U029")

--- a/src/test/kotlin/no/nav/eux/pdf/integration/common/HttpEntity.kt
+++ b/src/test/kotlin/no/nav/eux/pdf/integration/common/HttpEntity.kt
@@ -3,23 +3,6 @@ package no.nav.eux.pdf.integration.common
 import com.nimbusds.jose.JOSEObjectType
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
-
-fun <T> T.httpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity(this, mockOAuth2Server.httpHeaders)
-
-fun voidHttpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity<Void>(mockOAuth2Server.httpHeaders)
-
-val MockOAuth2Server.httpHeaders: HttpHeaders
-    get() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        headers.set("Authorization", "Bearer ${this.token}")
-        return headers
-    }
 
 val MockOAuth2Server.token: String
     get() = this


### PR DESCRIPTION
Replace TestRestTemplate with Spring Framework 7 RestTestClient for test HTTP calls.